### PR TITLE
Remove only root element in App.vue

### DIFF
--- a/generator/templates/src/App.vue
+++ b/generator/templates/src/App.vue
@@ -1,16 +1,14 @@
 <template>
-  <div id="app">
-    <img src="./assets/logo.png">
-    <div>
-      <p>
-        If Element Plus is successfully added to this project, you'll see an
-        <code v-text="'<el-button>'"></code>
-        below
-      </p>
-      <el-button type="primary">el-button</el-button>
-    </div>
-    <HelloWorld msg="Welcome to Your Vue.js App"/>
+  <img src="./assets/logo.png">
+  <div>
+    <p>
+      If Element Plus is successfully added to this project, you'll see an
+      <code v-text="'<el-button>'"></code>
+      below
+    </p>
+    <el-button type="primary">el-button</el-button>
   </div>
+  <HelloWorld msg="Welcome to Your Vue.js App"/>
 </template>
 
 <script>


### PR DESCRIPTION
It's unnecessary to contain only one root element in components in Vue 3 although it's necessary in Vue 2
It will show two ```<div id="app"></div>``` in Vue 3
![](https://img.ams1.imgbed.xyz/2021/01/17/RFMdS.png)

