### PR TITLE
Fix Bad Regex Causing Error

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -38,7 +38,7 @@ module.exports = (api, opts, rootOptions) => {
     const contentMain = fs.readFileSync(api.resolve(api.entryFile), { encoding: 'utf-8' })
     const lines = contentMain.split(/\r?\n/g)
 
-    const renderIndex = lines.findIndex(line => line.match(/createApp\(App\)(\.use\(\w*\))*\.mount\('#app'\)/))
+    const renderIndex = lines.findIndex(line => line.match(/createApp\(App\)(\.use\(\w*\))*\.mount\(['"]#app['"]\)/))
     const renderContent = lines[renderIndex]
     lines[renderIndex] = `const app = createApp(App)`
     lines[renderIndex + 1] = `installElementPlus(app)`


### PR DESCRIPTION
Fixes `Cannot read property 'replace' of undefined` error.

Regex is not working with app generated with latest version of vue-cli due to use of double quotes.

This fix address [this issue](https://github.com/element-plus/vue-cli-plugin-element-plus/issues/12)